### PR TITLE
removed requirement on client_secret

### DIFF
--- a/lib/passport-oauth2-client-password/strategy.js
+++ b/lib/passport-oauth2-client-password/strategy.js
@@ -35,7 +35,7 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body['client_id'] || !req.body['client_secret'])) {
+  if (!req.body || !req.body['client_id']) {
     return this.fail();
   }
 


### PR DESCRIPTION
it's entirely possible a system is configured with client_id but no secret - i.e. some providers (e.g. Ping) allow this